### PR TITLE
Fetch OpenStreetMap data using the Overpass API instead of OSM's Editing API

### DIFF
--- a/lib/request.ts
+++ b/lib/request.ts
@@ -3,7 +3,7 @@ import { progress } from "./progress";
 
 export async function request(bbox: [number, number, number, number]) {
   const res = await fetch(
-    `https://api.openstreetmap.org/api/0.6/map?bbox=${bbox.join(",")}`,
+    `https://overpass-api.de/api/interpreter?data=%5Bout%3Ajson%5D%5Btimeout%3A30%5D%3B%28node%28${bbox[1]}%2C${bbox[0]}%2C${bbox[3]}%2C${bbox[2]}%29%3B%3C%3Bnode%28w%29%3B%29%3Bout%3B`
     {
       /**
        * Figma doesn't support Headers()


### PR DESCRIPTION
OSM's main editing API (`https://api.openstreetmap.org/api/0.6/…`) is not intended for purely read-only use cases like this one. For downloading OSM data for purposes other than editing one should rather use a service like the Overpass API. [OSM's API usage policy](https://operations.osmfoundation.org/policies/api/) words it like this:

> The editing API is provided in order to edit the map data, not for read-only purposes or projects. 

See https://wiki.openstreetmap.org/wiki/API_v0.6#General_information and https://wiki.openstreetmap.org/wiki/Downloading_data#For_editing for additional background.

This replaces the OSM "map" API call with an (for the uses in this project) equivalent Overpass query[^1]:

```
[timeout:30][out:json];
(
  node({{bbox}}); // fetch all nodes in the queried area
  <; // also fetch ways and relations which reference these nodes
  node(w); // fetch remaining nodes belonging to ways which extend to outside of the query area
);
out;
```

This change reduces the load on OSM's main editing API and also has the benefit that fewer "too zoomed-out" errors should occur, as the Overpass API typically is able to return larger amounts of data more quickly and doesn't have any hardcoded bbox size limits.

<hr>

Note that this PR comes "untested", as I'm not very familiar with figma and in particular don't know how to test such a plugin in it. It is my educated guess though that everything should continue to work. A few details to consider / double-check are perhaps: a) error handling: the Overpass API can under some circumstances (e.g. when a timeout is hit) answer with an HTTP 200 status, but the result having incomplete and invalid JSON data; b) request headers: these are probably not needed anymore as the overpass query explicitly specifies the output format; c) metadata: the overpass query is written to not include metadata like element modification timestamps, user ids/names, changeset ids, etc. because as far as I see these metadata properties are not used in the plugin.

[^1]: I chose a relatively short timeout of 30 seconds in the query above, because everything which would take longer to be processed by the Overpass API is very likely too much to be further processed by an application like figma.