### PR TITLE
Fix for undefined coreutils

### DIFF
--- a/build.js
+++ b/build.js
@@ -66,6 +66,7 @@ esbuild
     outfile: "dist/backend.js",
     logLevel: "info",
     target: "es6",
+    platform: "browser",
     watch: {
       onRebuild(error, result) {
         if (error) console.error("watch build (code) failed:", error);

--- a/package.json
+++ b/package.json
@@ -38,8 +38,9 @@
     "leaflet": "^1.9.4",
     "leaflet-control-geocoder": "^2.4.0",
     "linelabel": "^0.1.1",
-    "osmtogeojson": "3.0.0-beta.5",
+    "osmtogeojson": "2.2.12",
     "polylabel": "^1.1.0",
     "rbush": "^3.0.1"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
I was getting a few issues with osmtogeojson on plugin load.

The issue was that osmtogeojson version 3.0.0-beta.5 bundles a version of lodash that requires `window.__core-js_shared__`, which cannot be set in Figma's restrictive sandbox environment (you can't define properties on window / root). I initially tried to change the banner in the build script but fundamentally I wasn't able to modify the environment.

I've downgraded the package to version 2.2.12, which is a stable release that doesn't have this dependency issue. 

**Changes made**:
* Updated package.json to use osmtogeojson version 2.2.12
* Removed the polyfill banner from build.js since it's no longer needed
* Reinstalled dependencies with the new version