### PR TITLE
Make the overpass query more precise

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,6 +1,8 @@
 import esbuild from "esbuild";
 import Fs from "node:fs";
 
+const shouldWatch = process.argv[2] === "--watch";
+
 Fs.watchFile("lib/ui.html", (curr, prev) => {
   buildTemplate();
 });
@@ -21,39 +23,35 @@ function buildTemplate() {
   Fs.writeFileSync("dist/ui.html", replaced);
 }
 
-const context = await esbuild
-  .context({
-    entryPoints: ["lib/ui.css"],
-    bundle: true,
-    outfile: "dist/ui.css",
-    loader: {
-      ".png": "dataurl",
-    },
-    logLevel: "info",
-  })
-  .catch(() => process.exit(1));
+const context = await esbuild[shouldWatch ? "context" : "build"]({
+  entryPoints: ["lib/ui.css"],
+  bundle: true,
+  outfile: "dist/ui.css",
+  loader: {
+    ".png": "dataurl",
+  },
+  logLevel: "info",
+}).catch(() => process.exit(1));
 
-await context.watch();
+const context2 = await esbuild[shouldWatch ? "context" : "build"]({
+  entryPoints: ["lib/ui.ts"],
+  bundle: true,
+  outfile: "dist/ui.js",
+  logLevel: "info",
+}).catch(() => process.exit(1));
 
-const context2 = await esbuild
-  .context({
-    entryPoints: ["lib/ui.ts"],
-    bundle: true,
-    outfile: "dist/ui.js",
-    logLevel: "info",
-  })
-  .catch(() => process.exit(1));
+const context3 = await esbuild[shouldWatch ? "context" : "build"]({
+  entryPoints: ["lib/backend.ts"],
+  bundle: true,
+  outfile: "dist/backend.js",
+  logLevel: "info",
+  target: "es6",
+}).catch(() => process.exit(1));
 
-await context2.watch();
-
-const context3 = await esbuild
-  .context({
-    entryPoints: ["lib/backend.ts"],
-    bundle: true,
-    outfile: "dist/backend.js",
-    logLevel: "info",
-    target: "es6",
-  })
-  .catch(() => process.exit(1));
-
-await context3.watch();
+if (shouldWatch) {
+  await context.watch();
+  await context2.watch();
+  await context3.watch();
+} else {
+  process.exit(0);
+}

--- a/lib/backend.ts
+++ b/lib/backend.ts
@@ -103,7 +103,7 @@ if (attached) {
         bbox: data.bbox,
       });
     }
-  } catch (e) {}
+  } catch {}
 } else {
   void figma.clientStorage.getAsync(STORAGE_KEY).then((stored) => {
     if (stored) {

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -1,11 +1,33 @@
 import { RootObject } from "./types";
 import { progress } from "./progress";
+import { TAGS_FOR_QUERY } from "./tags";
 
 export async function request(bbox: [number, number, number, number]) {
   // Overpass appears to use lat/lon bbox order
   const bboxString = [bbox[1], bbox[0], bbox[3], bbox[2]].join(",");
 
-  const query = `[out:json][timeout:30];(node(${bboxString});<;node(w););out;`;
+  // Query only the specific features we need instead of all nodes/ways
+  // This is much more efficient than downloading all nodes then all ways
+  const query = `[out:json][timeout:30];(
+    // Highways (roads)
+    way["highway"~"^(${TAGS_FOR_QUERY.highway})$"](${bboxString});
+    // Buildings
+    way["building"](${bboxString});
+    // Natural features
+    way["natural"~"^(${TAGS_FOR_QUERY.natural})$"](${bboxString});
+    // Landuse
+    way["landuse"~"^(industrial|commercial|retail|residential|pond|basin|reservoir|salt_pond|forest|railway|flowerbed|grass|cemetery|recreation_ground|village_green)$"](${bboxString});
+    // Leisure
+    way["leisure"~"^(${TAGS_FOR_QUERY.leisure})$"](${bboxString});
+    // Railway
+    way["railway"](${bboxString});
+    // Educational amenities
+    way["amenity"~"^(${TAGS_FOR_QUERY.amenity})$"](${bboxString});
+    // Parking structures
+    way["parking"~"^(${TAGS_FOR_QUERY.parking})$"](${bboxString});
+    // Individual trees (points)
+    node["natural"="tree"](${bboxString});
+  ); out geom;`;
 
   const res = await fetch(
     `https://overpass-api.de/api/interpreter?data=${encodeURIComponent(query)}`,
@@ -16,7 +38,7 @@ export async function request(bbox: [number, number, number, number]) {
       headersObject: {
         Accept: "application/json",
       },
-    } as unknown as RequestInit
+    } as unknown as RequestInit,
   );
 
   progress("Getting text");

--- a/lib/tags.ts
+++ b/lib/tags.ts
@@ -63,13 +63,44 @@ const paths = new Set([
   "pedestrian",
 ]);
 
+const parking = new Set(["multi-storey", "sheds", "carports", "garage_boxes"]);
+
+const landuseWater = new Set(["pond", "basin", "reservoir", "salt_pond"]);
+const naturalWater = new Set(["water", "coastline", "bay"]);
+
+const highwaysQuery = new Set([
+  ...supermajor_traffic_roads,
+  ...major_traffic_roads,
+  ...traffic_roads,
+  ...service_roads,
+  ...paths,
+]);
+
+const naturalQuery = new Set([...naturalWater, "tree", "wood"]);
+
+const landuseQuery = new Set([
+  ...landuseWater,
+  ...landuse,
+  "industrial",
+  "commercial",
+  "retail",
+  "residential",
+  "forest",
+  "railway",
+]);
+
+export const TAGS_FOR_QUERY = {
+  amenity: Array.from(educational).join("|"),
+  parking: Array.from(parking).join("|"),
+  leisure: Array.from(leisure).join("|"),
+  landuse: Array.from(landuseQuery).join("|"),
+  highway: Array.from(highwaysQuery).join("|"),
+  natural: Array.from(naturalQuery).join("|"),
+};
+
 export function isBuilding(tags: Tags) {
   return (
-    (!!tags.building && tags.building !== "no") ||
-    tags.parking === "multi-storey" ||
-    tags.parking === "sheds" ||
-    tags.parking === "carports" ||
-    tags.parking === "garage_boxes"
+    (!!tags.building && tags.building !== "no") || parking.has(tags.parking)
   );
 }
 
@@ -79,13 +110,8 @@ export function isWaterLine(tags: Tags) {
 
 export function isWater(tags: Tags) {
   return (
-    tags.natural === "water" ||
-    tags.natural === "coastline" ||
-    tags.natural === "bay" ||
-    tags.landuse === "pond" ||
-    tags.landuse === "basin" ||
-    tags.landuse === "reservoir" ||
-    tags.landuse === "salt_pond" ||
+    naturalWater.has(tags.natural) ||
+    landuseWater.has(tags.landuse) ||
     tags.leisure === "swimming_pool"
   );
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "main": "code.js",
   "scripts": {
     "build": "node build.js",
+    "watch": "node build.js --watch",
     "lint": "eslint lib/**/*.ts",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },
   "author": "Tom MacWright",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,13 @@
 {
   "compilerOptions": {
-    "moduleResolution": "node",
-    "target": "es6",
+    "moduleResolution": "bundler",
+    "target": "es2020",
     "allowSyntheticDefaultImports": true,
-    "lib": ["es6", "dom"],
+    "lib": ["es2020", "dom"],
     "strict": true,
     "noEmit": true,
-    "typeRoots": ["./node_modules/@types", "./node_modules/@figma"]
+    "typeRoots": ["./node_modules/@types", "./node_modules/@figma"],
+    "module": "esnext",
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
This is for two reasons:

- To tee up for having a variable query, so that on other zoom levels we eliminate houses etc
- To make existing usage faster because it will remove unused data from the downloaded set.

Overpass is still 504'ing a lot, more than I remembered, but I think this helps a bit.